### PR TITLE
With the Vanilla Psycast Expanded mod enabled, the Iguf firmware will…

### DIFF
--- a/HSK more content/Defs/BodyParts/BodyParts_Bionic.xml
+++ b/HSK more content/Defs/BodyParts/BodyParts_Bionic.xml
@@ -59,6 +59,7 @@
 				<statFactors>
 					<IncomingDamageFactor>0.75</IncomingDamageFactor>
 					<WorkSpeedGlobal>0.75</WorkSpeedGlobal>
+					<PsychicSensitivity MayRequire="VanillaExpanded.VPsycastsE">0</PsychicSensitivity>
 				</statFactors>
 				<statOffsets>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>


### PR DESCRIPTION
… reset the carrier's psychosensitivity to prevent the Iguf faction pawns from turning into whipping boys

При включенном моде Vanilla Psycast Expanded прошивка игуф будет обнулять психочувствительность носителя во избежание превращения пешек фракции игуф в мальчиков для битья