### PR TITLE
Some tweaks & fixes (01.2026).

### DIFF
--- a/HSK more content/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
+++ b/HSK more content/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
@@ -27,7 +27,7 @@
 			<SwayFactor>1.5</SwayFactor>
 			<Bulk>1.5</Bulk>
 			<Mass>0.9</Mass>
-			<RangedWeapon_Cooldown>0.2</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.3</RangedWeapon_Cooldown>
 		</statBases>
 		<tradeability>Sellable</tradeability>
 		<weaponTags>
@@ -45,7 +45,7 @@
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Projectile_SlingBall_Stone</defaultProjectile>
-				<warmupTime>0.25</warmupTime>
+				<warmupTime>0.35</warmupTime>
 				<range>19.1</range>
 				<soundCast>ThrowGrenade</soundCast>
 				<muzzleFlashScale>0</muzzleFlashScale>

--- a/HSK more content/Defs/ThingDefs_Weapons/Weapons_Turrets_Sentry.xml
+++ b/HSK more content/Defs/ThingDefs_Weapons/Weapons_Turrets_Sentry.xml
@@ -252,7 +252,7 @@
 				<minRange>2.5</minRange>
 				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
 				<burstShotCount>2</burstShotCount>
-				<soundCast>Shot_M24SR</soundCast>
+				<soundCast>Shot_SV98SR</soundCast>
 				<soundCastTail>GunTail_Light</soundCastTail>
 				<muzzleFlashScale>9</muzzleFlashScale>
 			</li>

--- a/HSK more content/Defs/TraderKindDefs/TraderKinds_Orbital_Foodtrader.xml
+++ b/HSK more content/Defs/TraderKindDefs/TraderKinds_Orbital_Foodtrader.xml
@@ -4,7 +4,7 @@
 	<TraderKindDef>
 		<defName>ZaurTrader_HMC</defName>
 		<label>liquor seller Zaur</label>
-		<commonality>0.25</commonality>
+		<commonality>0.15</commonality>
 		<orbital>true</orbital>
 		<stockGenerators>
 			<li Class="StockGenerator_SingleDef">

--- a/HSK more content/Defs/TraitDefs/Trait_HMC_Singular.xml
+++ b/HSK more content/Defs/TraitDefs/Trait_HMC_Singular.xml
@@ -45,7 +45,7 @@
 
 	<TraitDef>
 		<defName>HMC_GrassSnake</defName>
-		<commonality>0.4</commonality>
+		<commonality>0.2</commonality>
 		<degreeDatas>
 			<li>
 				<label>grass snake</label>
@@ -154,7 +154,16 @@
 				<label>efficaciousness</label>
 				<description>{PAWN_nameDef} - perfection itself.</description>
 				<statOffsets>
-					<WorkSpeedGlobal>0.40</WorkSpeedGlobal>
+					<WorkSpeedGlobal>0.10</WorkSpeedGlobal>
+					<MoveSpeed>0.1</MoveSpeed>
+					<ImmunityGainSpeed>0.1</ImmunityGainSpeed>
+					<GlobalLearningFactor>0.1</GlobalLearningFactor>
+					<CarryBulk>10</CarryBulk>
+					<CarryWeight>10</CarryWeight>
+					<CarryingCapacity>10</CarryingCapacity>
+					<MeleeDodgeChance>0.1</MeleeDodgeChance>
+					<AimingDelayFactor>-0.1</AimingDelayFactor>
+					<Suppressability>-0.1</Suppressability>
 				</statOffsets>
 			</li>
 		</degreeDatas>
@@ -415,7 +424,7 @@
 
 	<TraitDef>
 		<defName>HMC_SeekerOfDeepSense</defName>
-		<commonality>0.5</commonality>
+		<commonality>0.45</commonality>
 		<degreeDatas>
 			<li>
 				<label>seeker of the deep sense</label>

--- a/HSK more content/Patches/BodyPartsPatches.xml
+++ b/HSK more content/Patches/BodyPartsPatches.xml
@@ -40,6 +40,7 @@
 				<value>
 					<li>InstallIgufFirmware</li>
 					<li>RemoveIgufFirmware</li>
+					<li>InstallHMC_ArchotechCombatArm</li>
 				</value>
 			</li>
 		</operations>


### PR DESCRIPTION
[ENG]
- Replaced Marksman sentry micro-turret's firing sound with a quieter one.
- Slightly decreased the sling's rate of fire.
- Slightly decreased the chance of a liquor seller appearing.
- Reworked the "Efficaciousness" trait.
- Slightly decreased the chance of the "Grass snake" and "Seeker of the deep sense" traits appearing.
- Fixed archtech battle arm implatation fix.

[RUS]
- заменен звук выстрела марксманской авто-турели на менее громкий;
- немного снижена скорострельность пращи;
- немного снижен шанс появления торговца выпивки;
- переработана черта "Эффективность" для большего соответствия своему описанию;
- немного снижена вероятность появления черт "Уж" и "Искатель глубинного смысла";
- исправлена ​​невозможность имплантации полисиловой архоруки для не-андроидов.